### PR TITLE
Fix build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN \
       apt-get install -y build-essential && \
       apt-get install -y golang && \
       apt-get install -y pkg-config && \
+      apt-get install -y libyaml-dev && \
       apt-get clean && \
       rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM rubylang/ruby:3.2.2-jammy
 
 RUN \
       apt-get update -qq && \
-      apt-get install -y curl libsqlite3-dev && \
-      apt-get install -y build-essential && \
-      apt-get install -y golang && \
-      apt-get install -y pkg-config && \
-      apt-get install -y libyaml-dev && \
+      apt-get install -yq curl libsqlite3-dev && \
+      apt-get install -yq build-essential && \
+      apt-get install -yq golang && \
+      apt-get install -yq pkg-config && \
+      apt-get install -yq libyaml-dev && \
       apt-get clean && \
       rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Problem

![image](https://github.com/ujihisa/ruby-slackbot/assets/11504/1a6089a0-b3ac-4b4b-9090-7bc3dbbf84ca)

## Solution

Install libyaml.h via libyaml-dev ubuntu package

Also we don't need the details of the installation process when it's succeeding. This reduces the noise at Google Cloud Build.